### PR TITLE
SJQ2T-16: Dockerised databases, cleaned up dependencies

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -31,3 +31,6 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Cassandra ###
+out/

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,22 +1,22 @@
 services:
 
-  mysqldb:
-    image: mysql:8
-    container_name: mysqldb
+  skynest-db:
+    image: mysql:latest
+    container_name: skynest-db
     ports:
-      - 3305:3306
+      - 3306:3306
     restart: unless-stopped
     volumes:
       - db:/var/lib/mysql
     environment:
-      MYSQL_DATABASE: 'SkyNest'
+      MYSQL_DATABASE: 'skynest'
       MYSQL_USER: 'user'
       MYSQL_PASSWORD: '123456'
       MYSQL_ROOT_PASSWORD: '123456'
 
-  cassandra:
+  skynest-token-db:
     image: cassandra:latest
-    container_name: cassandra
+    container_name: skynest-token-db
     ports:
       - 9042:9042
     environment:
@@ -31,11 +31,11 @@ services:
       timeout: 10s
       retries: 10
 
-  cassandra-load-keyspace:
-    container_name: cassandra-load-keyspace
+  skynest-token-db-init:
+    container_name: skynest-token-db-init
     image: cassandra:latest
     depends_on:
-      cassandra:
+      skynest-token-db:
         condition: service_healthy
     volumes:
       - ./src/main/resources/cassandra_init_keyspace.cql:/schema.cql

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+
+  mysqldb:
+    image: mysql:8
+    container_name: mysqldb
+    ports:
+      - 3305:3306
+    restart: unless-stopped
+    volumes:
+      - db:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: 'SkyNest'
+      MYSQL_USER: 'user'
+      MYSQL_PASSWORD: '123456'
+      MYSQL_ROOT_PASSWORD: '123456'
+
+  cassandra:
+    image: cassandra:latest
+    container_name: cassandra
+    ports:
+      - 9042:9042
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    restart: unless-stopped
+    volumes:
+      - ./out/cassandra_data:/var/lib/cassandra
+    healthcheck:
+      test: [ "CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces" ]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+
+  cassandra-load-keyspace:
+    container_name: cassandra-load-keyspace
+    image: cassandra:latest
+    depends_on:
+      cassandra:
+        condition: service_healthy
+    volumes:
+      - ./src/main/resources/cassandra_init_keyspace.cql:/schema.cql
+    command: /bin/bash -c "echo loading cassandra keyspace && cqlsh cassandra -f /schema.cql"
+
+volumes:
+  db:

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -17,49 +17,67 @@
         <java.version>11</java.version>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
-        </dependency>
+
+        <!--    CORE    -->
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-web -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!--    SECURITY    -->
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!--    DATABASE    -->
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-jpa -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-security -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.6.8</version>
-        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.flywaydb/flyway-core -->
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-data-cassandra -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-cassandra</artifactId>
+        </dependency>
 
+        <!--    UTILS   -->
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.modelmapper/modelmapper -->
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
             <version>3.1.0</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.8</version>
         </dependency>
 
     </dependencies>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,8 +1,22 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/SkyNest?createDatabaseIfNotExist=true
+
+#   MySQL
+spring.datasource.url=jdbc:mysql://localhost:3305/SkyNest?createDatabaseIfNotExist=true
 spring.datasource.username=user
 spring.datasource.password=123456
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.flyway.baseline-on-migrate=true
 #spring.jpa.hibernate.ddl-auto=none
 #spring.jpa.show-sql: true
+
+#   Docs
 #springdoc.swagger-ui.path=/swagger-ui.html
+
+#   Cassandra
+spring.data.cassandra.contact-points=localhost
+spring.data.cassandra.port=9042
+spring.data.cassandra.username=cassandra
+spring.data.cassandra.password=cassandra
+spring.data.cassandra.cluster-name=Test Cluster
+spring.data.cassandra.local-datacenter=datacenter1
+spring.data.cassandra.keyspace-name=tokenkeyspace
+spring.data.cassandra.schema-action=CREATE_IF_NOT_EXISTS

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,15 +1,10 @@
 
 #   MySQL
-spring.datasource.url=jdbc:mysql://localhost:3305/SkyNest?createDatabaseIfNotExist=true
+spring.datasource.url=jdbc:mysql://localhost:3306/skynest?createDatabaseIfNotExist=true
 spring.datasource.username=user
 spring.datasource.password=123456
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect
 spring.flyway.baseline-on-migrate=true
-#spring.jpa.hibernate.ddl-auto=none
-#spring.jpa.show-sql: true
-
-#   Docs
-#springdoc.swagger-ui.path=/swagger-ui.html
 
 #   Cassandra
 spring.data.cassandra.contact-points=localhost

--- a/backend/src/main/resources/cassandra_init_keyspace.cql
+++ b/backend/src/main/resources/cassandra_init_keyspace.cql
@@ -1,0 +1,2 @@
+CREATE KEYSPACE IF NOT EXISTS tokenkeyspace
+WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 };


### PR DESCRIPTION
Docker compose sets up three services:
- one for MySQL
- one for Cassandra
- and a third service that waits for Cassandra to initialise and creates a keyspace (schema), if one doesn't exist

MySQL connects to port 3306 by default, so the dockerised version is visible through a different port (3305).

Should we also run maven from docker-compose?