### PR TITLE
SJQ2T-228: BE - Files and Folders must have unique names

### DIFF
--- a/backend/src/main/java/com/htecgroup/skynest/filter/CustomAuthorizationFilter.java
+++ b/backend/src/main/java/com/htecgroup/skynest/filter/CustomAuthorizationFilter.java
@@ -22,6 +22,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Log4j2
 @AllArgsConstructor
@@ -80,11 +82,20 @@ public class CustomAuthorizationFilter extends OncePerRequestFilter {
       ExceptionUtil.writeToResponse(errorMessage, response);
     } catch (Exception ex) {
       log.error(ex);
+
+      List<String> messages = new ArrayList<>();
+      Throwable currentException = ex;
+      while (currentException != null && currentException != currentException.getCause()) {
+        messages.add(currentException.getLocalizedMessage());
+        currentException = currentException.getCause();
+      }
+
       ErrorMessage errorMessage =
           new ErrorMessage(
-              ex.getMessage(),
+              messages,
               HttpStatus.INTERNAL_SERVER_ERROR.value(),
               DateTimeUtil.currentTimeFormatted());
+
       ExceptionUtil.writeToResponse(errorMessage, response);
     }
   }

--- a/backend/src/main/resources/db/migration/V8.1__file_trigger_before_insert_unique_name.sql
+++ b/backend/src/main/resources/db/migration/V8.1__file_trigger_before_insert_unique_name.sql
@@ -1,0 +1,11 @@
+DELIMITER //
+CREATE TRIGGER `file_before_insert_unique_name`
+  BEFORE INSERT ON `file`
+  FOR EACH ROW
+BEGIN
+  IF EXISTS(SELECT * FROM `file` f JOIN `object` o ON (f.id=o.id) WHERE o.name=(SELECT o1.name FROM `object` o1 WHERE o1.id = NEW.id) AND f.parent_folder_id<=>NEW.parent_folder_id AND f.bucket_id=NEW.bucket_id) THEN
+    DELETE FROM `object` WHERE `object`.id = NEW.id;
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'File name must be unique within a folder';
+  END IF;
+END//
+DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.2__file_trigger_before_update_unique_name.sql
+++ b/backend/src/main/resources/db/migration/V8.2__file_trigger_before_update_unique_name.sql
@@ -3,8 +3,10 @@ CREATE TRIGGER `file_before_update_unique_name`
   BEFORE UPDATE ON `file`
   FOR EACH ROW
 BEGIN
-  IF EXISTS(SELECT * FROM `file` f JOIN `object` o ON (f.id=o.id) WHERE o.name=(SELECT o1.name FROM `object` o1 WHERE o1.id = NEW.id) AND f.parent_folder_id<=>NEW.parent_folder_id AND f.bucket_id=NEW.bucket_id) THEN
-    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'File name must be unique within a folder';
+  IF NOT (OLD.parent_folder_id<=>NEW.parent_folder_id AND OLD.bucket_id=NEW.bucket_id) THEN
+    IF EXISTS(SELECT * FROM `file` f JOIN `object` o ON (f.id=o.id) WHERE o.name=(SELECT o1.name FROM `object` o1 WHERE o1.id = NEW.id) AND f.parent_folder_id<=>NEW.parent_folder_id AND f.bucket_id=NEW.bucket_id) THEN
+      SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'File name must be unique within a folder';
+    END IF;
   END IF;
 END//
 DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.2__file_trigger_before_update_unique_name.sql
+++ b/backend/src/main/resources/db/migration/V8.2__file_trigger_before_update_unique_name.sql
@@ -1,0 +1,10 @@
+DELIMITER //
+CREATE TRIGGER `file_before_update_unique_name`
+  BEFORE UPDATE ON `file`
+  FOR EACH ROW
+BEGIN
+  IF EXISTS(SELECT * FROM `file` f JOIN `object` o ON (f.id=o.id) WHERE o.name=(SELECT o1.name FROM `object` o1 WHERE o1.id = NEW.id) AND f.parent_folder_id<=>NEW.parent_folder_id AND f.bucket_id=NEW.bucket_id) THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'File name must be unique within a folder';
+  END IF;
+END//
+DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.3__folder_trigger_before_insert_unique_name.sql
+++ b/backend/src/main/resources/db/migration/V8.3__folder_trigger_before_insert_unique_name.sql
@@ -1,0 +1,11 @@
+DELIMITER //
+CREATE TRIGGER `folder_before_insert_unique_name`
+  BEFORE INSERT ON `folder`
+  FOR EACH ROW
+BEGIN
+  IF EXISTS(SELECT * FROM `folder` f JOIN `object` o ON (f.id=o.id) WHERE o.name=(SELECT o1.name FROM `object` o1 WHERE o1.id = NEW.id) AND f.parent_folder_id<=>NEW.parent_folder_id AND f.bucket_id=NEW.bucket_id) THEN
+    DELETE FROM `object` WHERE `object`.id = NEW.id;
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Folder name must be unique within a folder';
+  END IF;
+END//
+DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.4__folder_trigger_before_update_unique_name.sql
+++ b/backend/src/main/resources/db/migration/V8.4__folder_trigger_before_update_unique_name.sql
@@ -1,0 +1,10 @@
+DELIMITER //
+CREATE TRIGGER `folder_before_update_unique_name`
+  BEFORE UPDATE ON `folder`
+  FOR EACH ROW
+BEGIN
+  IF EXISTS(SELECT * FROM `folder` f JOIN `object` o ON (f.id=o.id) WHERE o.name=(SELECT o1.name FROM `object` o1 WHERE o1.id = NEW.id) AND f.parent_folder_id<=>NEW.parent_folder_id AND f.bucket_id=NEW.bucket_id) THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Folder name must be unique within a folder';
+  END IF;
+END//
+DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.4__folder_trigger_before_update_unique_name.sql
+++ b/backend/src/main/resources/db/migration/V8.4__folder_trigger_before_update_unique_name.sql
@@ -3,8 +3,10 @@ CREATE TRIGGER `folder_before_update_unique_name`
   BEFORE UPDATE ON `folder`
   FOR EACH ROW
 BEGIN
-  IF EXISTS(SELECT * FROM `folder` f JOIN `object` o ON (f.id=o.id) WHERE o.name=(SELECT o1.name FROM `object` o1 WHERE o1.id = NEW.id) AND f.parent_folder_id<=>NEW.parent_folder_id AND f.bucket_id=NEW.bucket_id) THEN
-    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Folder name must be unique within a folder';
+  IF NOT (OLD.parent_folder_id<=>NEW.parent_folder_id AND OLD.bucket_id=NEW.bucket_id) THEN
+    IF EXISTS(SELECT * FROM `folder` f JOIN `object` o ON (f.id=o.id) WHERE o.name=(SELECT o1.name FROM `object` o1 WHERE o1.id = NEW.id) AND f.parent_folder_id<=>NEW.parent_folder_id AND f.bucket_id=NEW.bucket_id) THEN
+      SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Folder name must be unique within a folder';
+    END IF;
   END IF;
 END//
 DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.5__object_trigger_before_update_unique_filename.sql
+++ b/backend/src/main/resources/db/migration/V8.5__object_trigger_before_update_unique_filename.sql
@@ -3,8 +3,10 @@ CREATE TRIGGER `object_before_update_unique_filename`
   BEFORE UPDATE ON `object`
   FOR EACH ROW
 BEGIN
-  IF EXISTS(SELECT * FROM `object` o JOIN `file` f ON (o.id=f.id) WHERE o.name=NEW.name AND f.parent_folder_id<=>(SELECT f1.parent_folder_id FROM `file` f1 WHERE f1.id=NEW.id) AND f.bucket_id=(SELECT f2.bucket_id FROM `file` f2 WHERE f2.id=NEW.id)) THEN
-    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'File name must be unique within a folder';
+  IF NOT (OLD.name=NEW.name) THEN
+    IF EXISTS(SELECT * FROM `object` o JOIN `file` f ON (o.id=f.id) WHERE o.name=NEW.name AND f.parent_folder_id<=>(SELECT f1.parent_folder_id FROM `file` f1 WHERE f1.id=NEW.id) AND f.bucket_id=(SELECT f2.bucket_id FROM `file` f2 WHERE f2.id=NEW.id)) THEN
+      SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'File name must be unique within a folder';
+    END IF;
   END IF;
 END//
 DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.5__object_trigger_before_update_unique_filename.sql
+++ b/backend/src/main/resources/db/migration/V8.5__object_trigger_before_update_unique_filename.sql
@@ -1,0 +1,10 @@
+DELIMITER //
+CREATE TRIGGER `object_before_update_unique_filename`
+  BEFORE UPDATE ON `object`
+  FOR EACH ROW
+BEGIN
+  IF EXISTS(SELECT * FROM `object` o JOIN `file` f ON (o.id=f.id) WHERE o.name=NEW.name AND f.parent_folder_id<=>(SELECT f1.parent_folder_id FROM `file` f1 WHERE f1.id=NEW.id) AND f.bucket_id=(SELECT f2.bucket_id FROM `file` f2 WHERE f2.id=NEW.id)) THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'File name must be unique within a folder';
+  END IF;
+END//
+DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.6__object_trigger_before_update_unique_folder_name.sql
+++ b/backend/src/main/resources/db/migration/V8.6__object_trigger_before_update_unique_folder_name.sql
@@ -1,0 +1,10 @@
+DELIMITER //
+CREATE TRIGGER `object_before_update_unique_folder_name`
+  BEFORE UPDATE ON `object`
+  FOR EACH ROW
+BEGIN
+  IF EXISTS(SELECT * FROM `object` o JOIN `folder` f ON (o.id=f.id) WHERE o.name=NEW.name AND f.parent_folder_id<=>(SELECT f1.parent_folder_id FROM `folder` f1 WHERE f1.id=NEW.id) AND f.bucket_id=(SELECT f2.bucket_id FROM `folder` f2 WHERE f2.id=NEW.id)) THEN
+    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Folder name must be unique within a folder';
+  END IF;
+END//
+DELIMITER ;

--- a/backend/src/main/resources/db/migration/V8.6__object_trigger_before_update_unique_folder_name.sql
+++ b/backend/src/main/resources/db/migration/V8.6__object_trigger_before_update_unique_folder_name.sql
@@ -3,8 +3,10 @@ CREATE TRIGGER `object_before_update_unique_folder_name`
   BEFORE UPDATE ON `object`
   FOR EACH ROW
 BEGIN
-  IF EXISTS(SELECT * FROM `object` o JOIN `folder` f ON (o.id=f.id) WHERE o.name=NEW.name AND f.parent_folder_id<=>(SELECT f1.parent_folder_id FROM `folder` f1 WHERE f1.id=NEW.id) AND f.bucket_id=(SELECT f2.bucket_id FROM `folder` f2 WHERE f2.id=NEW.id)) THEN
-    SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Folder name must be unique within a folder';
+  IF NOT (OLD.name=NEW.name) THEN
+    IF EXISTS(SELECT * FROM `object` o JOIN `folder` f ON (o.id=f.id) WHERE o.name=NEW.name AND f.parent_folder_id<=>(SELECT f1.parent_folder_id FROM `folder` f1 WHERE f1.id=NEW.id) AND f.bucket_id=(SELECT f2.bucket_id FROM `folder` f2 WHERE f2.id=NEW.id)) THEN
+      SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'Folder name must be unique within a folder';
+    END IF;
   END IF;
 END//
 DELIMITER ;


### PR DESCRIPTION
* added triggers to enforce unique names for files and folders (inside of a folder)

* generic errors now have all causes displayed

This doesn't cover bucket names. Should they be unique? Since they are shared between a bunch of people, how would that work?