### PR TITLE
SJQ2T-255: BE - Name and last name fields in edit user details are accepting numbers

### DIFF
--- a/backend/src/main/java/com/htecgroup/skynest/model/request/UserEditRequest.java
+++ b/backend/src/main/java/com/htecgroup/skynest/model/request/UserEditRequest.java
@@ -16,10 +16,12 @@ public class UserEditRequest {
 
   @NotBlank(message = "cannot be null or empty")
   @Size(max = 50, message = "length cannot be over 50")
+  @Pattern(regexp = RegexUtil.USER_NAME_AND_SURNAME_REGEX, message = "format not valid")
   private String name;
 
   @NotBlank(message = "cannot be null or empty")
   @Size(max = 100, message = "length cannot be over 100")
+  @Pattern(regexp = RegexUtil.USER_NAME_AND_SURNAME_REGEX, message = "format not valid")
   private String surname;
 
   @NotBlank(message = "cannot be null or empty")

--- a/backend/src/main/java/com/htecgroup/skynest/model/request/UserRegisterRequest.java
+++ b/backend/src/main/java/com/htecgroup/skynest/model/request/UserRegisterRequest.java
@@ -26,10 +26,12 @@ public class UserRegisterRequest {
 
   @NotBlank(message = "cannot be null or empty")
   @Size(max = 50, message = "length cannot be over 50")
+  @Pattern(regexp = RegexUtil.USER_NAME_AND_SURNAME_REGEX, message = "format not valid")
   private String name;
 
   @NotBlank(message = "cannot be null or empty")
   @Size(max = 100, message = "length cannot be over 100")
+  @Pattern(regexp = RegexUtil.USER_NAME_AND_SURNAME_REGEX, message = "format not valid")
   private String surname;
 
   @NotBlank(message = "cannot be null or empty")

--- a/backend/src/main/java/com/htecgroup/skynest/util/RegexUtil.java
+++ b/backend/src/main/java/com/htecgroup/skynest/util/RegexUtil.java
@@ -11,4 +11,6 @@ public class RegexUtil {
       "[a-zA-Z0-9_+&*-]{1,64}(?:\\.[a-zA-Z0-9_+&*-]+){0,64}@(?:[a-zA-Z0-9-]+\\.){1,255}[a-zA-Z]{2,7}";
 
   public static final String PIB_FORMAT_REGEX = "[1-9]\\d{8}";
+
+  public static final String USER_NAME_AND_SURNAME_REGEX = "[A-Za-z\\-\\s]+";
 }


### PR DESCRIPTION
Added regex for user name and surname. Now accepting only letters, '-' and 'space'.