### PR TITLE
SJQ2T-337: Clearer endpoint names

### DIFF
--- a/backend/src/main/java/com/htecgroup/skynest/controller/BucketController.java
+++ b/backend/src/main/java/com/htecgroup/skynest/controller/BucketController.java
@@ -103,7 +103,7 @@ public class BucketController {
     return bucketResponseEntity;
   }
 
-  @Operation(summary = "Get bucket with given uuid")
+  @Operation(summary = "Get bucket details")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -164,9 +164,9 @@ public class BucketController {
                   examples = {@ExampleObject(value = "Internal Server Error")})
             })
       })
-  @GetMapping("/{uuid}")
-  public ResponseEntity<BucketResponse> getBucket(@PathVariable UUID uuid) {
-    BucketResponse bucketResponse = bucketService.getBucket(uuid);
+  @GetMapping("/{bucketId}/info")
+  public ResponseEntity<BucketResponse> getBucket(@PathVariable UUID bucketId) {
+    BucketResponse bucketResponse = bucketService.getBucket(bucketId);
     ResponseEntity<BucketResponse> bucketResponseEntity =
         new ResponseEntity<>(bucketResponse, HttpStatus.OK);
     return bucketResponseEntity;
@@ -288,13 +288,13 @@ public class BucketController {
                   })
             })
       })
-  @PutMapping("delete/{uuid}")
-  public ResponseEntity<Boolean> deleteBucket(@PathVariable UUID uuid) {
-    bucketService.deleteBucket(uuid);
+  @PutMapping("/{bucketId}/delete")
+  public ResponseEntity<Boolean> deleteBucket(@PathVariable UUID bucketId) {
+    bucketService.deleteBucket(bucketId);
     return ResponseEntity.ok(true);
   }
 
-  @Operation(summary = "Restore Bucket")
+  @Operation(summary = "Restore bucket")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -352,9 +352,9 @@ public class BucketController {
                   })
             })
       })
-  @PutMapping("/{uuid}/restore")
-  public ResponseEntity<Boolean> restoreBucket(@PathVariable UUID uuid) {
-    bucketService.restoreBucket(uuid);
+  @PutMapping("/{bucketId}/restore")
+  public ResponseEntity<Boolean> restoreBucket(@PathVariable UUID bucketId) {
+    bucketService.restoreBucket(bucketId);
     return ResponseEntity.ok(true);
   }
 
@@ -425,11 +425,11 @@ public class BucketController {
                   })
             })
       })
-  @PutMapping("/{uuid}")
+  @PutMapping("/{bucketId}")
   public ResponseEntity<BucketResponse> editBucket(
-      @Valid @RequestBody BucketEditRequest bucketEditRequest, @PathVariable UUID uuid) {
+      @Valid @RequestBody BucketEditRequest bucketEditRequest, @PathVariable UUID bucketId) {
     ResponseEntity<BucketResponse> bucketResponseEntity =
-        new ResponseEntity<>(bucketService.editBucket(bucketEditRequest, uuid), HttpStatus.OK);
+        new ResponseEntity<>(bucketService.editBucket(bucketEditRequest, bucketId), HttpStatus.OK);
     return bucketResponseEntity;
   }
 }

--- a/backend/src/main/java/com/htecgroup/skynest/controller/CompanyController.java
+++ b/backend/src/main/java/com/htecgroup/skynest/controller/CompanyController.java
@@ -169,7 +169,7 @@ public class CompanyController {
     return responseEntity;
   }
 
-  @Operation(summary = "Edit a company")
+  @Operation(summary = "Edit current user's company")
   @ApiResponses(
       value = {
         @ApiResponse(

--- a/backend/src/main/java/com/htecgroup/skynest/controller/FileController.java
+++ b/backend/src/main/java/com/htecgroup/skynest/controller/FileController.java
@@ -33,7 +33,7 @@ public class FileController {
 
   private final FileService fileService;
 
-  @Operation(summary = "Upload a new file to a bucket")
+  @Operation(summary = "Upload file to a bucket")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -166,9 +166,9 @@ public class FileController {
                   examples = {@ExampleObject(value = "Internal Server Error")})
             })
       })
-  @PostMapping(path = "/bucket/{uuid}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PostMapping(path = "/bucket/{bucketId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<FileResponse> uploadFileToBucket(
-      @PathVariable(name = "uuid") UUID bucketId, @RequestPart("file") MultipartFile file) {
+      @PathVariable UUID bucketId, @RequestPart("file") MultipartFile file) {
 
     FileResponse fileResponse = fileService.uploadFile(file, bucketId);
 
@@ -176,7 +176,7 @@ public class FileController {
     return responseEntity;
   }
 
-  @Operation(summary = "Download a file")
+  @Operation(summary = "Download file")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -261,8 +261,8 @@ public class FileController {
                   examples = {@ExampleObject(value = "Internal Server Error")})
             })
       })
-  @GetMapping(path = "/{uuid}")
-  public ResponseEntity<Resource> downloadFile(@PathVariable(name = "uuid") UUID fileId) {
+  @GetMapping(path = "/{fileId}")
+  public ResponseEntity<Resource> downloadFile(@PathVariable UUID fileId) {
 
     FileDownloadResponse fileDownloadResponse = fileService.downloadFile(fileId);
 
@@ -277,7 +277,7 @@ public class FileController {
     return responseEntity;
   }
 
-  @Operation(summary = "Get file info")
+  @Operation(summary = "Get file details")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -358,8 +358,8 @@ public class FileController {
                   examples = {@ExampleObject(value = "Internal Server Error")})
             })
       })
-  @GetMapping("/{uuid}/info")
-  public ResponseEntity<FileResponse> getFileDetails(@PathVariable(name = "uuid") UUID fileId) {
+  @GetMapping("/{fileId}/info")
+  public ResponseEntity<FileResponse> getFileDetails(@PathVariable UUID fileId) {
 
     FileResponse fileResponse = fileService.getFileMetadata(fileId);
     ResponseEntity<FileResponse> responseEntity = new ResponseEntity<>(fileResponse, HttpStatus.OK);

--- a/backend/src/main/java/com/htecgroup/skynest/controller/FolderController.java
+++ b/backend/src/main/java/com/htecgroup/skynest/controller/FolderController.java
@@ -101,7 +101,7 @@ public class FolderController {
     return folderResponseEntity;
   }
 
-  @Operation(summary = "Get folder with given uuid")
+  @Operation(summary = "Get folder info")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -161,9 +161,9 @@ public class FolderController {
                   examples = {@ExampleObject(value = "Internal Server Error")})
             })
       })
-  @GetMapping("/{uuid}/info")
-  public ResponseEntity<FolderResponse> getFolderDetails(@PathVariable UUID uuid) {
-    FolderResponse folderResponse = folderService.getFolderDetails(uuid);
+  @GetMapping("/{folderId}/info")
+  public ResponseEntity<FolderResponse> getFolderDetails(@PathVariable UUID folderId) {
+    FolderResponse folderResponse = folderService.getFolderDetails(folderId);
     ResponseEntity<FolderResponse> folderResponseEntity =
         new ResponseEntity<>(folderResponse, HttpStatus.OK);
     return folderResponseEntity;

--- a/backend/src/main/java/com/htecgroup/skynest/controller/UserController.java
+++ b/backend/src/main/java/com/htecgroup/skynest/controller/UserController.java
@@ -106,7 +106,7 @@ public class UserController {
     return listOfUsers;
   }
 
-  @Operation(summary = "Get user with given uuid")
+  @Operation(summary = "Get user")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -189,15 +189,15 @@ public class UserController {
       })
   @PreAuthorize(
       "hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN) or hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_WORKER)")
-  @GetMapping("/{uuid}")
-  public ResponseEntity<UserResponse> getUser(@PathVariable UUID uuid) {
-    UserResponse userResponse = userService.getUser(uuid);
+  @GetMapping("/{userId}")
+  public ResponseEntity<UserResponse> getUser(@PathVariable UUID userId) {
+    UserResponse userResponse = userService.getUser(userId);
     ResponseEntity<UserResponse> userResponseEntity =
         new ResponseEntity<>(userResponse, HttpStatus.OK);
     return userResponseEntity;
   }
 
-  @Operation(summary = "Edit user with given uuid")
+  @Operation(summary = "Edit user")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -280,16 +280,16 @@ public class UserController {
       })
   @PreAuthorize(
       "hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN) or hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_WORKER)")
-  @PutMapping("/{uuid}")
+  @PutMapping("/{userId}")
   public ResponseEntity<UserResponse> editUser(
-      @Valid @RequestBody UserEditRequest userEditRequest, @PathVariable UUID uuid) {
+      @Valid @RequestBody UserEditRequest userEditRequest, @PathVariable UUID userId) {
     ResponseEntity<UserResponse> responseEntity =
-        new ResponseEntity<>(userService.editUser(uuid, userEditRequest), HttpStatus.OK);
+        new ResponseEntity<>(userService.editUser(userId, userEditRequest), HttpStatus.OK);
     log.info("User is successfully edited.");
     return responseEntity;
   }
 
-  @Operation(summary = "Delete user with given uuid")
+  @Operation(summary = "Delete user")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -359,9 +359,9 @@ public class UserController {
             })
       })
   @PreAuthorize("hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN)")
-  @DeleteMapping("/{uuid}")
-  public ResponseEntity<String> deleteUser(@PathVariable UUID uuid) {
-    userService.deleteUser(uuid);
+  @DeleteMapping("/{userId}")
+  public ResponseEntity<String> deleteUser(@PathVariable UUID userId) {
+    userService.deleteUser(userId);
     String deleteSuccess = "User was successfully deleted from database";
     log.info(deleteSuccess);
     return ResponseEntity.ok(deleteSuccess);
@@ -427,13 +427,13 @@ public class UserController {
       })
   @PreAuthorize(
       "hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN) or hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_WORKER)")
-  @PutMapping("/password-change/{uuid}")
+  @PutMapping("/{userId}/password-change")
   public ResponseEntity<Boolean> changePassword(
       @Valid @RequestBody UserChangePasswordRequest userChangePasswordRequest,
-      @PathVariable UUID uuid) {
-    userService.authorizeAccessForChangePassword(uuid);
-    userService.changePassword(userChangePasswordRequest, uuid);
-    log.info("User with id {} successfully changed their password", uuid);
+      @PathVariable UUID userId) {
+    userService.authorizeAccessForChangePassword(userId);
+    userService.changePassword(userChangePasswordRequest, userId);
+    log.info("User with id {} successfully changed their password", userId);
     return ResponseEntity.ok(true);
   }
 
@@ -496,10 +496,10 @@ public class UserController {
             })
       })
   @PreAuthorize("hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN)")
-  @PutMapping("/{uuid}/enable")
-  public ResponseEntity<Boolean> enableUser(@PathVariable UUID uuid) {
-    userService.enableUser(uuid);
-    log.info("User with id {} was successfully enabled", uuid);
+  @PutMapping("/{userId}/enable")
+  public ResponseEntity<Boolean> enableUser(@PathVariable UUID userId) {
+    userService.enableUser(userId);
+    log.info("User with id {} was successfully enabled", userId);
     return ResponseEntity.ok(true);
   }
 
@@ -562,10 +562,10 @@ public class UserController {
             })
       })
   @PreAuthorize("hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN)")
-  @PutMapping("/{uuid}/disable")
-  public ResponseEntity<Boolean> disableUser(@PathVariable UUID uuid) {
-    userService.disableUser(uuid);
-    log.info("User with id {} was successfully disabled", uuid);
+  @PutMapping("/{userId}/disable")
+  public ResponseEntity<Boolean> disableUser(@PathVariable UUID userId) {
+    userService.disableUser(userId);
+    log.info("User with id {} was successfully disabled", userId);
     return ResponseEntity.ok(true);
   }
 
@@ -628,10 +628,10 @@ public class UserController {
             }),
       })
   @PreAuthorize("hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN)")
-  @PutMapping("/{uuid}/promote")
-  public ResponseEntity<Boolean> promoteUser(@PathVariable UUID uuid) {
-    userService.promoteUser(uuid);
-    log.info("User with id {} was successfully promoted to manager", uuid);
+  @PutMapping("/{userId}/promote")
+  public ResponseEntity<Boolean> promoteUser(@PathVariable UUID userId) {
+    userService.promoteUser(userId);
+    log.info("User with id {} was successfully promoted to manager", userId);
     return ResponseEntity.ok(true);
   }
 
@@ -694,10 +694,10 @@ public class UserController {
             }),
       })
   @PreAuthorize("hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN)")
-  @PutMapping("/{uuid}/demote")
-  public ResponseEntity<Boolean> demoteUser(@PathVariable UUID uuid) {
-    userService.demoteUser(uuid);
-    log.info("User with id {} was successfully demoted to worker", uuid);
+  @PutMapping("/{userId}/demote")
+  public ResponseEntity<Boolean> demoteUser(@PathVariable UUID userId) {
+    userService.demoteUser(userId);
+    log.info("User with id {} was successfully demoted to worker", userId);
     return ResponseEntity.ok(true);
   }
 
@@ -745,7 +745,7 @@ public class UserController {
     return ResponseEntity.ok(loggedUser);
   }
 
-  @Operation(summary = "Add company for user")
+  @Operation(summary = "Add user to current user's company")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -806,14 +806,14 @@ public class UserController {
             }),
       })
   @PreAuthorize("hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN)")
-  @PutMapping("/{uuid}/company/add")
-  public ResponseEntity<Boolean> addCompanyForUser(@PathVariable UUID uuid) {
-    userService.addCompanyForUser(uuid);
-    log.info("Successfully added company to user {}", uuid);
+  @PutMapping("/{userId}/company/add")
+  public ResponseEntity<Boolean> addCompanyForUser(@PathVariable UUID userId) {
+    userService.addCompanyForUser(userId);
+    log.info("Successfully added company to user {}", userId);
     return ResponseEntity.ok(true);
   }
 
-  @Operation(summary = "Remove company for user")
+  @Operation(summary = "Remove user from current user's company")
   @ApiResponses(
       value = {
         @ApiResponse(
@@ -872,10 +872,10 @@ public class UserController {
             }),
       })
   @PreAuthorize("hasAuthority(T(com.htecgroup.skynest.model.entity.RoleEntity).ROLE_ADMIN)")
-  @PutMapping("/{uuid}/company/remove")
-  public ResponseEntity<Boolean> removeCompanyForUser(@PathVariable UUID uuid) {
-    userService.removeCompany(uuid);
-    log.info("Successfully removed company for user {}", uuid);
+  @PutMapping("/{userId}/company/remove")
+  public ResponseEntity<Boolean> removeCompanyForUser(@PathVariable UUID userId) {
+    userService.removeCompany(userId);
+    log.info("Successfully removed company for user {}", userId);
     return ResponseEntity.ok(true);
   }
 }

--- a/frontend/src/Components/HomePage/Profile/ChangePassword.jsx
+++ b/frontend/src/Components/HomePage/Profile/ChangePassword.jsx
@@ -25,7 +25,7 @@ const ChangePassword = ({ userID }) => {
    const handlePasswordChange = async () => {
       try {
          await AxiosInstance.put(
-            `/users/password-change/${userID}`,
+            `/users/${userID}/password-change/`,
             {
                currentPassword,
                newPassword,


### PR DESCRIPTION
* switched to bucketId, folderId, fileId… instead of uuid

* ids go before operations, so <code>users/{userId}/password-change/</code> rather than <code>users/password-change/{userId}</code>